### PR TITLE
Fix issue caused by deprecated function

### DIFF
--- a/src-IL/src/il_png.c
+++ b/src-IL/src/il_png.c
@@ -278,7 +278,7 @@ ILboolean readpng_get_image(ILdouble display_exponent)
 
 	// Expand low-bit-depth grayscale images to 8 bits
 	if (png_color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
-		png_set_gray_1_2_4_to_8(png_ptr);
+		png_set_expand_gray_1_2_4_to_8(png_ptr);
 	}
 
 	// Expand RGB images with transparency to full alpha channels


### PR DESCRIPTION
"The function png_set_gray_1_2_4_to_8() was removed. It has been deprecated since libpng-1.0.18 and 1.2.9, when it was replaced with png_set_expand_gray_1_2_4_to_8() because the former function also expanded palette images."